### PR TITLE
Added space between transaction and hash

### DIFF
--- a/ui/views/tx/tx-view.js
+++ b/ui/views/tx/tx-view.js
@@ -21,7 +21,7 @@ export default function TxView() {
     if (error) throw error
     if (!txInfo) return <div className="loader"/>
     return <>
-        <h2>Transaction
+        <h2>Transaction 
             <BlockSelect inline wrap className="condensed">{txhash}</BlockSelect>
             <span className="text-small"><CopyToClipboard text={txhash}/></span>
         </h2>


### PR DESCRIPTION
can also use &nbsp instead of just a space.

Solved 2nd request in #3 